### PR TITLE
Avoid caching compilation data and use value equality for SyntaxNodes

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodIndexData.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/VirtualMethodIndexData.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Interop
     /// <summary>
     /// VirtualMethodIndexAttribute data
     /// </summary>
-    internal sealed record VirtualMethodIndexData(int Index) : InteropAttributeData
+    internal sealed record VirtualMethodIndexData(int Index) : InteropAttributeCompilationData
     {
         public bool ImplicitThisParameter { get; init; }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Common/DefaultMarshallingInfoParser.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Common/DefaultMarshallingInfoParser.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Interop
 {
     internal static class DefaultMarshallingInfoParser
     {
-        public static MarshallingInfoParser Create(StubEnvironment env, IGeneratorDiagnostics diagnostics, IMethodSymbol method, InteropAttributeData interopAttributeData, AttributeData unparsedAttributeData)
+        public static MarshallingInfoParser Create(StubEnvironment env, IGeneratorDiagnostics diagnostics, IMethodSymbol method, InteropAttributeCompilationData interopAttributeData, AttributeData unparsedAttributeData)
         {
 
             // Compute the current default string encoding value.

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportAnalyzer.cs
@@ -155,9 +155,9 @@ namespace Microsoft.Interop.Analyzers
                 || unmanagedType == UnmanagedType.SafeArray;
         }
 
-        private static InteropAttributeData CreateInteropAttributeDataFromDllImport(DllImportData dllImportData)
+        private static InteropAttributeCompilationData CreateInteropAttributeDataFromDllImport(DllImportData dllImportData)
         {
-            InteropAttributeData interopData = new();
+            InteropAttributeCompilationData interopData = new();
             if (dllImportData.SetLastError)
             {
                 interopData = interopData with { IsUserDefined = interopData.IsUserDefined | InteropAttributeMember.SetLastError, SetLastError = true };

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportData.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportData.cs
@@ -1,17 +1,27 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Runtime.InteropServices;
-using Microsoft.CodeAnalysis;
-
 namespace Microsoft.Interop
 {
     /// <summary>
     /// LibraryImportAttribute data
     /// </summary>
-    internal sealed record LibraryImportData(string ModuleName) : InteropAttributeData
+    internal sealed record LibraryImportCompilationData(string ModuleName) : InteropAttributeCompilationData
     {
         public string EntryPoint { get; init; }
+    }
+
+    internal sealed record LibraryImportData(string ModuleName) : InteropAttributeModelData
+    {
+        public string EntryPoint { get; init; }
+
+        public static LibraryImportData From(LibraryImportCompilationData libraryImport)
+            => new LibraryImportData(libraryImport.ModuleName) with
+            {
+                EntryPoint = libraryImport.EntryPoint,
+                IsUserDefined = libraryImport.IsUserDefined,
+                SetLastError = libraryImport.SetLastError,
+                StringMarshalling = libraryImport.StringMarshalling
+            };
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGenerator.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -181,7 +180,7 @@ namespace Microsoft.Interop
                 .WithBody(stubCode);
         }
 
-        private static LibraryImportData? ProcessLibraryImportAttribute(AttributeData attrData)
+        private static LibraryImportCompilationData? ProcessLibraryImportAttribute(AttributeData attrData)
         {
             // Found the LibraryImport, but it has an error so report the error.
             // This is most likely an issue with targeting an incorrect TFM.
@@ -198,7 +197,7 @@ namespace Microsoft.Interop
             ImmutableDictionary<string, TypedConstant> namedArguments = ImmutableDictionary.CreateRange(attrData.NamedArguments);
 
             string? entryPoint = null;
-            if (namedArguments.TryGetValue(nameof(LibraryImportData.EntryPoint), out TypedConstant entryPointValue))
+            if (namedArguments.TryGetValue(nameof(LibraryImportCompilationData.EntryPoint), out TypedConstant entryPointValue))
             {
                 if (entryPointValue.Value is not string)
                 {
@@ -207,7 +206,7 @@ namespace Microsoft.Interop
                 entryPoint = (string)entryPointValue.Value!;
             }
 
-            return new LibraryImportData(attrData.ConstructorArguments[0].Value!.ToString())
+            return new LibraryImportCompilationData(attrData.ConstructorArguments[0].Value!.ToString())
             {
                 EntryPoint = entryPoint,
             }.WithValuesFromNamedArguments(namedArguments);
@@ -261,9 +260,9 @@ namespace Microsoft.Interop
             var generatorDiagnostics = new GeneratorDiagnostics();
 
             // Process the LibraryImport attribute
-            LibraryImportData libraryImportData =
+            LibraryImportCompilationData libraryImportData =
                 ProcessLibraryImportAttribute(generatedDllImportAttr!) ??
-                new LibraryImportData("INVALID_CSHARP_SYNTAX");
+                new LibraryImportCompilationData("INVALID_CSHARP_SYNTAX");
 
             if (libraryImportData.IsUserDefined.HasFlag(InteropAttributeMember.StringMarshalling))
             {
@@ -302,7 +301,7 @@ namespace Microsoft.Interop
                 methodSyntaxTemplate,
                 new MethodSignatureDiagnosticLocations(originalSyntax),
                 new SequenceEqualImmutableArray<AttributeSyntax>(additionalAttributes.ToImmutableArray(), SyntaxEquivalentComparer.Instance),
-                libraryImportData,
+                LibraryImportData.From(libraryImportData),
                 LibraryImportGeneratorHelpers.CreateGeneratorFactory(environment, options),
                 new SequenceEqualImmutableArray<Diagnostic>(generatorDiagnostics.Diagnostics.ToImmutableArray())
                 );

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedTypeInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManagedTypeInfo.cs
@@ -4,9 +4,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.Interop
 {
@@ -17,6 +14,19 @@ namespace Microsoft.Interop
     {
         private TypeSyntax? _syntax;
         public TypeSyntax Syntax => _syntax ??= SyntaxFactory.ParseTypeName(FullTypeName);
+
+        public virtual bool Equals(ManagedTypeInfo other)
+        {
+            return other is not null
+                && Syntax.IsEquivalentTo(other.Syntax)
+                && FullTypeName == other.FullTypeName
+                && DiagnosticFormattedName == other.DiagnosticFormattedName;
+        }
+
+        public override int GetHashCode()
+        {
+            return Syntax.GetHashCode() ^ FullTypeName.GetHashCode() ^ DiagnosticFormattedName.GetHashCode();
+        }
 
         protected ManagedTypeInfo(ManagedTypeInfo original)
         {

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/ManualTypeMarshallingHelper.cs
@@ -24,6 +24,22 @@ namespace Microsoft.Interop
     public readonly record struct CustomTypeMarshallers(
         ImmutableDictionary<MarshalMode, CustomTypeMarshallerData> Modes)
     {
+        public bool Equals(CustomTypeMarshallers other)
+        {
+            return Modes.Count == other.Modes.Count
+                && !Modes.Except(other.Modes).Any();
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 0;
+            foreach (KeyValuePair<MarshalMode, CustomTypeMarshallerData> mode in Modes)
+            {
+                hash ^= mode.Key.GetHashCode() ^ mode.Value.GetHashCode();
+            }
+            return hash;
+        }
+
         public CustomTypeMarshallerData GetModeOrDefault(MarshalMode mode)
         {
             CustomTypeMarshallerData data;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/IncrementalGenerationTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/IncrementalGenerationTests.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿//
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.CodeAnalysis;
@@ -217,8 +218,7 @@ namespace LibraryImportGenerator.UnitTests
             // Basic stub
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<int>() };
             // Stub with custom string marshaller
-            // TODO: Compilation is held alive by the CustomStringMarshallingType property in LibraryImportData
-            // yield return new[] { CodeSnippets.CustomStringMarshallingParametersAndModifiers<string>() }; 
+            yield return new[] { CodeSnippets.CustomStringMarshallingParametersAndModifiers<string>() }; 
         }
 
         // This test requires precise GC to ensure that we're accurately testing that we aren't


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/78242 from dotnet/runtime.

Creates separate types for InteropAttributeData: one that holds compilation data, and one that holds only the data necessary for the model to create the GeneratedCode.

This uncovered some issues with record equality in records that use `SyntaxNode`. For those, we need to override `Equals` or wrap the `SyntaxNode` in a type that overrides `Equals` to use `IsEquivalentTo` on the `SyntaxNode`.

There are probably more places where we use `SyntaxNode` that aren't caught in the current tests.

To make sure every record has the right equality, I wasn't sure if it would be better to override Equals for each of the records, or create a wrapper record struct for each SyntaxNode that implements the equality we want (and implicit casts to and from the SyntaxNode). Then we wouldn't have to explicitly override the equality in each record that has a SyntaxNode.

Also, I'm not sure if it makes more sense to add this PR to your branch or to dotnet/runtime, or somewhere else. Please let me know if I should move it.
